### PR TITLE
Feature automatically import

### DIFF
--- a/META.json
+++ b/META.json
@@ -46,6 +46,7 @@
             "Class::Load" : "0",
             "Function::Parameters" : "2.000003",
             "Function::Return" : "0.05",
+            "Import::Into" : "0",
             "Keyword::Simple" : "0.04",
             "PPR" : "0",
             "Type::Tiny" : "0",

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ and implements interface class:
 ```perl
 package Foo {
     use Function::Interface::Impl qw(IFoo);
-
-    use Function::Parameters;
-    use Function::Return;
     use Types::Standard -types;
 
     fun hello(Str $msg) :Return(Str) {

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Keyword::Simple', '0.04';
 requires 'Carp';
 requires 'Class::Load';
 requires 'Type::Tiny';
+requires 'Import::Into';
 
 on 'test' => sub {
     requires 'Test2::V0';

--- a/eg/lib/Foo.pm
+++ b/eg/lib/Foo.pm
@@ -1,9 +1,6 @@
 package Foo;
 
 use Function::Interface::Impl qw(IFoo);
-
-use Function::Return;
-use Function::Parameters;
 use Types::Standard -types;
 
 fun hello(Str $msg) :Return(Str) {

--- a/lib/Function/Interface.pm
+++ b/lib/Function/Interface.pm
@@ -225,9 +225,6 @@ and implements interface class:
 
     package Foo {
         use Function::Interface::Impl qw(IFoo);
-
-        use Function::Parameters;
-        use Function::Return;
         use Types::Standard -types;
 
         fun hello(Str $msg) :Return(Str) {

--- a/lib/Function/Interface/Impl.pm
+++ b/lib/Function/Interface/Impl.pm
@@ -7,6 +7,7 @@ our $VERSION = "0.03";
 
 use Class::Load qw(load_class try_load_class is_class_loaded);
 use Scalar::Util qw(blessed);
+use Import::Into;
 
 sub import {
     my $class = shift;
@@ -16,6 +17,9 @@ sub import {
     for (@interface_packages) {
         register_check_list($pkg, $_, $filename, $line);
     }
+
+    Function::Parameters->import::into($pkg);
+    Function::Return->import::into($pkg);
 }
 
 our @CHECK_LIST;

--- a/lib/Function/Interface/Impl.pm
+++ b/lib/Function/Interface/Impl.pm
@@ -163,9 +163,6 @@ Function::Interface::Impl - implements interface
 
     package Foo {
         use Function::Interface::Impl qw(IFoo);
-
-        use Function::Parameters;
-        use Function::Return;
         use Types::Standard -types;
 
         fun hello(Str $msg) :Return(Str) {

--- a/lib/Function/Interface/Impl.pm
+++ b/lib/Function/Interface/Impl.pm
@@ -97,6 +97,19 @@ sub info_params {
     Function::Parameters::info($code)
 }
 
+
+# XXX:
+# We want to call CHECK in the following order:
+# 1. Function::Return#CHECK (to get return info)
+# 2. Function::Interface::Impl#CHECK (to check implements)
+#
+# CHECK is LIFO.
+# So, it is necessary to load in the following order:
+# 1. Function::Interface::Impl
+# 2. Function::Return
+#
+# Because of this,
+# Function::Interface::Impl doesn't use Function::Return, but does load_class.
 sub info_return {
     my $code = shift;
     load_class('Function::Return');

--- a/t/03_function_interface_impl/import.t
+++ b/t/03_function_interface_impl/import.t
@@ -1,0 +1,8 @@
+use Test2::V0;
+
+use Function::Interface::Impl;
+
+ok $INC{'Function/Parameters.pm'}, 'loaded Function::Parameters';
+ok $INC{'Function/Return.pm'}, 'loaded Function::Return';
+
+done_testing;

--- a/t/lib/Bar.pm
+++ b/t/lib/Bar.pm
@@ -1,7 +1,5 @@
 package Bar;
 use Function::Interface::Impl qw(IBar);
-use Function::Parameters;
-use Function::Return;
 
 fun bar() :Return() { }
 

--- a/t/lib/Foo.pm
+++ b/t/lib/Foo.pm
@@ -1,7 +1,5 @@
 package Foo;
 use Function::Interface::Impl qw(IFoo);
-use Function::Parameters;
-use Function::Return;
 
 fun foo() :Return() { }
 

--- a/t/lib/FooBar.pm
+++ b/t/lib/FooBar.pm
@@ -1,7 +1,5 @@
 package FooBar;
 use Function::Interface::Impl qw(IFoo IBar);
-use Function::Parameters;
-use Function::Return;
 
 fun foo() :Return() { }
 fun bar() :Return() { }

--- a/t/lib/FooClone.pm
+++ b/t/lib/FooClone.pm
@@ -1,7 +1,5 @@
 package FooClone;
 use Function::Interface::Impl qw(IFoo);
-use Function::Parameters;
-use Function::Return;
 
 fun foo() :Return() { }
 

--- a/t/lib/FooInvalidParams.pm
+++ b/t/lib/FooInvalidParams.pm
@@ -1,7 +1,5 @@
 package FooInvalidParams;
 use Function::Interface::Impl qw(IFoo);
-use Function::Return;
-use Function::Parameters;
 
 use Types::Standard -types;
 

--- a/t/lib/FooInvalidReturn.pm
+++ b/t/lib/FooInvalidReturn.pm
@@ -1,7 +1,5 @@
 package FooInvalidReturn;
 use Function::Interface::Impl qw(IFoo);
-use Function::Return;
-use Function::Parameters;
 
 use Types::Standard -types;
 

--- a/t/lib/FooNoParamsInfo.pm
+++ b/t/lib/FooNoParamsInfo.pm
@@ -1,6 +1,5 @@
 package FooNoParamsInfo;
 use Function::Interface::Impl qw(IFoo);
-use Function::Return;
 
 sub foo :Return() {}
 

--- a/t/lib/FooNoReturnInfo.pm
+++ b/t/lib/FooNoReturnInfo.pm
@@ -1,6 +1,5 @@
 package FooNoReturnInfo;
 use Function::Interface::Impl qw(IFoo);
-use Function::Parameters;
 
 fun foo() {}
 

--- a/t/lib/FooObject.pm
+++ b/t/lib/FooObject.pm
@@ -1,7 +1,5 @@
 package FooObject;
 use Function::Interface::Impl qw(IFoo);
-use Function::Parameters;
-use Function::Return;
 
 fun foo() :Return() { }
 


### PR DESCRIPTION
automatically import Function::Parameters and Function::Return.

Reasons:
1. Convenient
2. To reduce errors due to the load order of Function::Return and Function::Interface::Impl
